### PR TITLE
chore: remove dependency on dom lib

### DIFF
--- a/src/buffer_source_converter.ts
+++ b/src/buffer_source_converter.ts
@@ -1,3 +1,5 @@
+export type BufferSource = ArrayBuffer | ArrayBufferView;
+
 export class BufferSourceConverter {
 
   public static toArrayBuffer(data: BufferSource) {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,9 +1,12 @@
-import { BufferSourceConverter } from './buffer_source_converter';
+import { BufferSource, BufferSourceConverter } from "./buffer_source_converter";
 
 export type BufferEncoding = "utf8" | "binary" | "base64" | "base64url" | "hex" | string;
 
-declare const unescape: (value: string) => string;
-declare const escape: (value: string) => string;
+// augment global scope with names whose availability varies by environment
+declare global {
+  var btoa: undefined | ((data: string) => string);
+  var atob: undefined | ((data: string) => string);
+}
 
 function PrepareBuffer(buffer: BufferSource) {
     if (typeof Buffer !== "undefined" && Buffer.isBuffer(buffer)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
         "module": "commonjs",
         "target": "ES2018",
         "lib": [
-            "es2015",
-            "dom"
+            "es2015"
         ],
         "noImplicitAny": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
The dom lib is incompatible with node, so using it to reference type
definitions forces downstream projects to use the --skipLibCheck
TypeScript option.

So, instead of referencing the few types provided by the dom lib, we can
simply provide them ourselves.

------------

👋 Hi, I've worked on a series of PRs today which will remove the small dependency on the dom lib from few packages that were in my transient dependency tree:
```
└─┬ @simplewebauthn/server@0.10.3
  └─┬ @peculiar/asn1-schema@2.0.23
    └─┬ @types/asn1js@0.0.2
      └── @types/pvutils@0.0.2
```

I started with `@types/pvutils` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49320) and worked my way up to `@types/asn1js` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49322) and then `@peculiar/asn1-schema`, which led me back down to here. 😅 

I apologize for coming straight in with a PR instead of opening an issue to discuss beforehand, but I firstly wanted to understand how widely the dom lib was depended upon, and when I found that it was small, I wanted to also verify that it could be safely removed. By the time I had done all that, I had all the changes staged, and since the changes were rather small, I thought it would be expeditious to simply propose them via PR. 🤗 