### PR TITLE
fix: BufferSourceConverter.toArrayBuffer with Node.js Buffer slice

### DIFF
--- a/src/buffer_source_converter.ts
+++ b/src/buffer_source_converter.ts
@@ -43,7 +43,12 @@ export class BufferSourceConverter {
       return data.buffer;
     }
 
-    return this.toUint8Array(data).slice().buffer;
+    // passing explicit offset values to work around the surprising behavior of
+    // Buffer.prototype.slice:
+    // https://nodejs.org/api/buffer.html#buffers-and-typedarrays
+    return this.toUint8Array(data.buffer)
+      .slice(data.byteOffset, data.byteOffset + data.byteLength)
+      .buffer;
   }
 
   /**

--- a/test/buffer_source_converter.ts
+++ b/test/buffer_source_converter.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import { BufferSourceConverter, Convert } from "../src";
+import { Buffer } from "node:buffer";
 
 context("BufferSourceConverter", () => {
 
@@ -50,6 +51,17 @@ context("BufferSourceConverter", () => {
     assert.throws(() => {
       BufferSourceConverter.toArrayBuffer(source as any);
     }, TypeError);
+  });
+
+  context("toArrayBuffer", () => {
+
+    it("keeps slice offsets for Node.js buffer slices", () => {
+      const size = 3;
+      const slice = Buffer.from(vector).slice(0, size);
+      const data = BufferSourceConverter.toArrayBuffer(slice);
+      assert.equal(data.byteLength, size);
+    });
+
   });
 
   context("isBufferSource", () => {


### PR DESCRIPTION
While using [PKI.js](https://github.com/PeculiarVentures/PKI.js) in Node.js v20 I ran into bugs where `BufferSourceConverter.toArrayBuffer` of a slice would return a copy of its original, larger, buffer. Likely the library was calling the deprecated `Buffer.prototype.slice` where it should have called `Buffer.prototype.subarray` instead. Currently, pvtsutils does not handle such a Buffer slice view correctly. This change fixes that.