### PR TITLE
Fix structural buffer source encoding

### DIFF
--- a/src/bytes/buffer-source.ts
+++ b/src/bytes/buffer-source.ts
@@ -20,6 +20,21 @@ function bytesPerElement(type: ViewConstructor): number {
   return value ?? 1;
 }
 
+function isArrayBufferViewLike(value: unknown): value is ArrayBufferViewLike {
+  if (ArrayBuffer.isView(value)) {
+    return true;
+  }
+
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const view = value as Partial<ArrayBufferViewLike>;
+  return typeof view.byteOffset === "number"
+    && typeof view.byteLength === "number"
+    && isArrayBufferLike(view.buffer);
+}
+
 function copyBytes(data: BufferSourceLike): Uint8Array {
   const view = toUint8Array(data);
   const copy = new Uint8Array(view.byteLength);
@@ -44,7 +59,7 @@ export function isArrayBufferLike(value: unknown): value is ArrayBufferLike {
 
 /** Checks whether a value is an ArrayBufferView. */
 export function isArrayBufferView(value: unknown): value is ArrayBufferViewLike {
-  return ArrayBuffer.isView(value);
+  return isArrayBufferViewLike(value);
 }
 
 /** Checks whether a value can be treated as a buffer source. */

--- a/src/bytes/bytes.spec.ts
+++ b/src/bytes/bytes.spec.ts
@@ -17,7 +17,7 @@ import {
 import { concat, concatToUint8Array } from "./concat.js";
 import { equal } from "./equal.js";
 import { compare, copy, endsWith, includes, indexOf, lastIndexOf, slice, startsWith, tail } from "./sequence.js";
-import type { BufferSourceLike } from "./types.js";
+import type { BufferSource, BufferSourceLike } from "./types.js";
 import * as bytesApi from "./index.js";
 
 function* makeBuffers(): Iterable<Uint8Array> {
@@ -46,6 +46,11 @@ describe("bytes", () => {
       expect(isArrayBufferLike(sharedBuffer)).toBe(true);
       expect(isBufferSource(sharedBuffer)).toBe(true);
     }
+  });
+
+  it("preserves the historical BufferSource type alias", () => {
+    expectTypeOf<BufferSource>().toEqualTypeOf<BufferSourceLike>();
+    expectTypeOf<BufferSourceLike>().toMatchTypeOf<BufferSource>();
   });
 
   it("normalizes buffer sources to Uint8Array views", () => {

--- a/src/bytes/index.ts
+++ b/src/bytes/index.ts
@@ -2,6 +2,7 @@
 export type {
   ArrayBufferViewLike,
   ArrayBufferViewConstructor,
+  BufferSource,
   BufferSourceLike,
   DataViewConstructorLike,
   StrictBufferSource,

--- a/src/bytes/types.ts
+++ b/src/bytes/types.ts
@@ -8,6 +8,9 @@ export interface ArrayBufferViewLike<TBuffer extends ArrayBufferLike = ArrayBuff
 /** A buffer source backed by either an ArrayBuffer-like value or a view. */
 export type BufferSourceLike = ArrayBufferLike | ArrayBufferViewLike;
 
+/** Historical BufferSource alias preserved for compatibility. */
+export type BufferSource = BufferSourceLike;
+
 /** A strict buffer source limited to ArrayBuffer and ArrayBuffer-backed views. */
 export type StrictBufferSource = ArrayBuffer | ArrayBufferViewLike<ArrayBuffer>;
 

--- a/src/encoding/encoding.spec.ts
+++ b/src/encoding/encoding.spec.ts
@@ -39,6 +39,20 @@ describe("encoding", () => {
     );
   });
 
+  it("encodes structural ArrayBufferView-like values", () => {
+    class OctetStringLike {
+      public buffer = new Uint8Array([0, 15, 16, 255]).buffer;
+      public readonly byteOffset = 0;
+
+      public readonly byteLength = this.buffer.byteLength;
+    }
+
+    const value = new OctetStringLike();
+
+    expect(encoding.hex.encode(value as never)).toBe("000f10ff");
+    expect(encoding.hex.is(value as never)).toBe(false);
+  });
+
   it("handles base64 helpers with and without Buffer", () => {
     const payload = new Uint8Array([104, 105]);
 


### PR DESCRIPTION
This restores compatibility with structural ArrayBufferView-like values such as `OctetString` from `asn1-schema`.

Changes:
- accept structural view-like objects in `isArrayBufferView`
- keep `hex.encode(...)` working for those values via `toUint8Array`
- add regression coverage for byte helpers and hex encoding

Validation:
- `npm run check`